### PR TITLE
introduce nginx to solve #6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3"
+services:
+  nginx:
+    build:
+      context: ./nginx
+    ports:
+      - "80:80"
+    depends_on:
+      - app
+    environment:
+      - APP_DOMAIN=${APP_DOMAIN}
+  app:
+    build: .
+    expose:
+      - "5000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - app
     environment:
       - APP_DOMAIN=${APP_DOMAIN}
+    restart: always
   app:
     build: .
-    expose:
-      - "5000"
+    restart: always

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:1.17
+EXPOSE 80
+ENV APP_DOMAIN=localhost
+COPY nginx.template /etc/nginx/nginx.template
+CMD ["/bin/bash", "-c", "host='$host' remote_addr='$remote_addr' envsubst < /etc/nginx/nginx.template > /etc/nginx/nginx.conf && exec nginx -g 'daemon off;'"]

--- a/nginx/nginx.template
+++ b/nginx/nginx.template
@@ -1,0 +1,21 @@
+events {
+
+}
+http {
+  server {
+    listen 80;
+    server_name $APP_DOMAIN;
+
+    location / {
+      proxy_pass http://app:5000/;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+    }
+  }
+  server {
+    listen 80 default_server;
+    server_name _;
+
+    return 404;
+  }
+}


### PR DESCRIPTION
`envsubst` has no way to escape `$` so we need a hack to keep `$remote_addr` and `$host` in `nginx.conf`.

This PR closes #6.